### PR TITLE
Fix client compilation and runtime hang

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/Go-Chat/pkg/chat"
 )
@@ -41,8 +40,6 @@ func (c *Client) Start(addr string) error {
 	}
 	c.conn = conn
 	defer c.conn.Close()
-
-	c.sendPublicKey()
 
 	go c.handleIncomingMessages()
 
@@ -110,11 +107,18 @@ func (c *Client) SendMessage(message string) {
 }
 
 func (c *Client) JoinRoom(roomName string) {
+	pemKey := x509.MarshalPKCS1PublicKey(c.publicKey)
+	keyss := chat.Keys{
+		Publick: pemKey,
+	}
+	public, _ := json.Marshal(keyss)
+	c.conn.Write(public)
+	c.conn.Write([]byte("\n"))
 	c.conn.Write([]byte(roomName + "\n"))
 }
 
-func (c.Client) SendUsername(username string) {
-    c.conn.Write([]byte(username + "\n"))
+func (c *Client) SendUsername(username string) {
+	c.conn.Write([]byte(username + "\n"))
 }
 
 func (c *Client) encrypt(msg []byte) ([]byte, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,9 +47,10 @@ func (s *Server) Start(addr string) error {
 
 func (s *Server) handleConnection(conn net.Conn) {
 	defer conn.Close()
+	reader := bufio.NewReader(conn)
 
 	// Read public key from client
-	hash, _ := bufio.NewReader(conn).ReadString('\n')
+	hash, _ := reader.ReadString('\n')
 	var keys chat.Keys
 	if err := json.Unmarshal([]byte(hash), &keys); err != nil {
 		fmt.Println(err)
@@ -58,14 +59,14 @@ func (s *Server) handleConnection(conn net.Conn) {
 	pubKey, _ := x509.ParsePKCS1PublicKey(keys.Publick)
 
 	// Read room name from client
-	roomName, _ := bufio.NewReader(conn).ReadString('\n')
+	roomName, _ := reader.ReadString('\n')
 	roomName = strings.TrimSpace(roomName)
 
 	// Get or create room
 	room := s.getOrCreateRoom(roomName, conn)
 
 	// Read username from client
-	username, _ := bufio.NewReader(conn).ReadString('\n')
+	username, _ := reader.ReadString('\n')
 	username = strings.TrimSpace(username)
 
 	client := &chat.Client{
@@ -80,7 +81,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 
 	for {
 		// Read message from client
-		message, err := bufio.NewReader(conn).ReadString('\n')
+		message, err := reader.ReadString('\n')
 		if err != nil {
 			s.broadcast(fmt.Sprintf("::: %s has left the room :::\n", username), room)
 			delete(room.Clients, conn)


### PR DESCRIPTION
This commit addresses several issues that prevented the client from running correctly.

The initial compilation errors were:
- An unused 'strings' import in client.go.
- An incorrect method receiver on the SendUsername function.

After fixing these, a runtime deadlock was discovered where the client would hang waiting for the server's public key. This was due to a protocol mismatch:
- The client sent its key and immediately waited for the server's key.
- The server waited for the client's key and then a room name before sending its key.

This was resolved by:
1.  Modifying the client to send its public key and the room name sequentially within the `JoinRoom` function, instead of sending the key on startup.
2.  Fixing a bug in the server where a new `bufio.Reader` was created for each network read, which could lead to data loss. The server now uses a single reader per connection.

These changes resolve the deadlock and allow the client to connect to the server successfully.